### PR TITLE
WebDAV: Add `PROPFIND` as an accepted HTTP method (fixes #300).

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -189,7 +189,7 @@
 (defconst restclient-empty-line-regexp "^\\s-*$")
 
 (defconst restclient-method-url-regexp
-  "^\\(GET\\|POST\\|DELETE\\|PUT\\|HEAD\\|OPTIONS\\|PATCH\\) \\(.*\\)$")
+  "^\\(GET\\|POST\\|DELETE\\|PUT\\|HEAD\\|OPTIONS\\|PATCH\\|PROPFIND\\) \\(.*\\)$")
 
 (defconst restclient-header-regexp
   "^\\([^](),/:;@[\\{}= \t]+\\): \\(.*\\)$")


### PR DESCRIPTION
Copy of https://github.com/pashky/restclient.el/pull/301